### PR TITLE
fixes the output format of #coefficients and #standard_error

### DIFF
--- a/lib/statsample-glm/glm/base.rb
+++ b/lib/statsample-glm/glm/base.rb
@@ -29,27 +29,38 @@ module Statsample
                             .new(@data_set, @dependent, @opts)
       end
       
-      def coefficients as_a=:array
-        if as_a == :hash
+      def coefficients as_a=:vector
+        case as_a
+        when :hash
           c = {}
           @data_set.vectors.to_a.each_with_index do |f,i|
             c[f.to_sym] = @regression.coefficients[i]
           end
-          return c
+          c
+        when :array
+          @regression.coefficients.to_a
+        when :vector
+          @regression.coefficients
+        else
+          raise ArgumentError, "as_a has to be one of :array, :hash, or :vector"
         end
-        create_vector @regression.coefficients
       end
 
-      def standard_error as_a=:array  
-        if as_a == :hash
+      def standard_error as_a=:vector  
+        case as_a
+        when :hash
           se = {}
           @data_set.vectors.to_a.each_with_index do |f,i|
             se[f.to_sym] = @regression.standard_error[i]
           end
-          return se
+          se
+        when :array
+          @regression.standard_error.to_a
+        when :vector
+          @regression.standard_error
+        else
+          raise ArgumentError, "as_a has to be one of :array, :hash, or :vector"
         end
-
-        create_vector @regression.standard_error
       end
 
       def iterations

--- a/lib/statsample-glm/glm/irls/base.rb
+++ b/lib/statsample-glm/glm/irls/base.rb
@@ -61,10 +61,10 @@ module Statsample
 
           @coefficients       = create_vector(b.column_vectors[0])
           @iterations         = max_iter
-          @standard_error     = hessian(@data_set,b).inverse
-                                                    .diagonal
-                                                    .map{ |x| -x}
-                                                    .map{ |y| Math.sqrt(y) }
+          @standard_error     = create_vector(hessian(@data_set,b).inverse
+                                                                  .diagonal
+                                                                  .map{ |x| -x}
+                                                                  .map{ |y| Math.sqrt(y) })
           @fitted_mean_values = create_vector measurement(@data_set,b).to_a.flatten
           @residuals          = @dependent - @fitted_mean_values
           @degree_of_freedom  = @dependent.count - @data_set.column_size

--- a/lib/statsample-glm/glm/mle/base.rb
+++ b/lib/statsample-glm/glm/mle/base.rb
@@ -42,7 +42,7 @@ module Statsample
             out << Math::sqrt(@var_cov_matrix[i,i])
           end
 
-          out
+          create_vector out
         end
 
         # Use the fitted GLM to obtain predictions on new data.

--- a/spec/logistic_spec.rb
+++ b/spec/logistic_spec.rb
@@ -9,14 +9,20 @@ describe Statsample::GLM::Logistic do
     end
 
     it "reports correct coefficients as an array" do
-      expect_similar_vector(@glm.coefficients,[-0.312493754568903,
-        2.28671333346264,0.675603176233325])
-
+      expect_similar_array(@glm.coefficients(:array), [-0.312493754568903,
+                                                       2.28671333346264,
+                                                       0.675603176233325])
     end
 
     it "reports correct coefficients as a hash" do
       expect_similar_hash(@glm.coefficients(:hash), {:constant => 0.675603176233325,
-        :x1 => -0.312493754568903, :x2 => 2.28671333346264})
+                                                     :x1 => -0.312493754568903,
+                                                     :x2 => 2.28671333346264})
+    end
+
+    it "reports correct coefficients as a Daru::Vector" do
+      expect_similar_vector(@glm.coefficients, [-0.312493754568903,
+                                                2.28671333346264, 0.675603176233325])
     end
 
     it "computes predictions on new data correctly" do
@@ -35,13 +41,38 @@ describe Statsample::GLM::Logistic do
       @glm      = Statsample::GLM.compute @data_set,:y, :logistic, {constant: 1, algorithm: :mle}
     end
 
-    it "reports correct regression values as an array" do
+    it "reports correct log-likelihood" do
       expect(@glm.log_likelihood).to be_within(0.001).of(-38.8669)
+    end
 
-      expect_similar_vector(@glm.coefficients, [0.3270, 0.8147, -0.4031,-5.3658],0.001)
-      expect_similar_vector(@glm.standard_error, [0.4390, 0.4270, 0.3819,1.9045],0.001)
-
+    it "report the correct number of iterations" do
       expect(@glm.iterations).to eq(7)
+    end
+
+    it "reports correct regression coefficients as a Daru::Vector" do
+      expect_similar_vector(@glm.coefficients, [0.3270, 0.8147, -0.4031,-5.3658], 0.001)
+    end
+
+    it "reports correct standard deviations as a Daru::Vector" do
+      expect_similar_vector(@glm.standard_error, [0.4390, 0.4270, 0.3819,1.9045], 0.001)
+    end
+
+    it "reports correct regression coefficients as an array" do
+      expect_similar_array(@glm.coefficients(:array), [0.3270, 0.8147, -0.4031,-5.3658], 0.001)
+    end
+
+    it "reports correct standard deviations as an array" do
+      expect_similar_array(@glm.standard_error(:array), [0.4390, 0.4270, 0.3819,1.9045], 0.001)
+    end
+
+    it "reports correct regression coefficients as a hash" do
+      expect_similar_hash(@glm.coefficients(:hash), {:a => 0.3270, :b => 0.8147, :c => -0.4031,
+                                                     :constant => -5.3658}, 0.001)
+    end
+
+    it "reports correct standard deviations as a hash" do
+      expect_similar_hash(@glm.standard_error(:hash), {:a => 0.4390, :b => 0.4270, :c => 0.3819,
+                                                       :constant => 1.9045}, 0.001)
     end
 
     it "computes predictions on new data correctly" do

--- a/spec/normal_spec.rb
+++ b/spec/normal_spec.rb
@@ -6,7 +6,7 @@ describe Statsample::GLM::Normal do
         order: ['ROLL', 'UNEM', 'HGRAD', 'INC']
     end
 
-    it "reports correct values as an array", focus: true do
+    it "reports correct values as a Daru::Vector", focus: true do
       @glm = Statsample::GLM.compute @ds, 'ROLL', :normal, {algorithm: :mle}
       
       expect_similar_vector @glm.coefficients, [450.12450365911894, 

--- a/spec/poisson_spec.rb
+++ b/spec/poisson_spec.rb
@@ -9,20 +9,28 @@ describe Statsample::GLM::Poisson do
 
     end
 
-    it "reports return values as arrays for IRLS" do
-      @glm    = Statsample::GLM.compute @df,:y,:poisson, 
-                  {algorithm: :irls, constant: 1}
+    it "reports return values a Daru::Vector for IRLS" do
+      @glm = Statsample::GLM.compute @df, :y, :poisson, {algorithm: :irls, constant: 1}
 
-      expect_similar_vector(@glm.coefficients,[-0.586359358356708,
-        1.28511323439258,0.32993246633711])
+      expect_similar_vector(@glm.coefficients, [-0.586359358356708,
+                                                1.28511323439258,
+                                                0.32993246633711])
     end
 
     it "reports return values as a hash for IRLS" do
-      @glm    = Statsample::GLM.compute @df,:y,:poisson, 
-                  {algorithm: :irls, constant: 1}
+      @glm = Statsample::GLM.compute @df, :y, :poisson, {algorithm: :irls, constant: 1}
 
       expect_similar_hash(@glm.coefficients(:hash), {:constant => 0.32993246633711,
-        :x1 => -0.586359358356708, :x2 => 1.28511323439258})
+                                                     :x1 => -0.586359358356708,
+                                                     :x2 => 1.28511323439258})
+    end
+
+    it "reports return values as an array for IRLS" do
+      @glm = Statsample::GLM.compute @df, :y, :poisson, {algorithm: :irls, constant: 1}
+
+      expect_similar_array(@glm.coefficients(:array), [-0.586359358356708,
+                                                       1.28511323439258,
+                                                       0.32993246633711])
     end
 
     it "computes predictions on new data correctly" do

--- a/spec/probit_spec.rb
+++ b/spec/probit_spec.rb
@@ -11,10 +11,21 @@ describe Statsample::GLM::Probit do
                     {algorithm: :mle, constant: 1}
     end
 
-    it "reports correct values as an array" do
-      expect_similar_vector(@glm.coefficients,[0.1763,0.4483,-0.2240,-3.0670],0.001)
-
+    it "reports correct log-likelihood" do
       expect(@glm.log_likelihood).to be_within(0.0001).of(-38.31559)
+    end
+
+    it "reports correct regression coefficients as a Daru::Vector" do
+      expect_similar_vector(@glm.coefficients,[0.1763,0.4483,-0.2240,-3.0670],0.001)
+    end
+
+    it "reports correct regression coefficients as an array" do
+      expect_similar_array(@glm.coefficients(:array),[0.1763,0.4483,-0.2240,-3.0670],0.001)
+    end
+
+    it "reports correct regression coefficients as a hash" do
+      expect_similar_hash(@glm.coefficients(:hash), {:a => 0.1763, :b => 0.4483, :c => -0.2240,
+                                                     :constant => -3.0670}, 0.001)
     end
 
     it "computes predictions on new data correctly" do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -15,6 +15,7 @@ $LOAD_PATH.unshift(File.dirname(__FILE__))
 require 'statsample-glm'
 
 def expect_similar_vector(exp, obs, delta=1e-10,msg=nil)
+  expect(exp.is_a? Daru::Vector).to be true
   expect(exp.size).to eq(obs.size)
 
   exp.to_a.each_with_index do |v,i|
@@ -23,6 +24,7 @@ def expect_similar_vector(exp, obs, delta=1e-10,msg=nil)
 end
 
 def expect_similar_hash(exp, obs, delta=1e-10,msg=nil)
+  expect(exp.is_a? Hash).to be true
   expect(exp.size).to eq(obs.size)
 
   exp.each_key do |k|
@@ -30,7 +32,17 @@ def expect_similar_hash(exp, obs, delta=1e-10,msg=nil)
   end
 end
 
+def expect_similar_array(exp, obs, delta=1e-10,msg=nil)
+  expect(exp.is_a? Array).to be true
+  expect(exp.size).to eq(obs.size)
+
+  exp.each_with_index do |v,i|
+    expect(v).to be_within(delta).of(obs[i])
+  end
+end
+
 def expect_equal_vector(exp,obs,delta=1e-10,msg=nil)
+  expect(exp.is_a? Daru::Vector).to be true
   expect(exp.size).to eq(obs.size)
 
   exp.size.times do |i|


### PR DESCRIPTION
The default argument `as_a` for the methods `#coefficients` and `#standard_error` was `as_a=:array`, but the returned output was a `Daru::Vector`.

These changes keep the returned output as a `Daru::Vector`, but change the default argument to be `as_a=:vector`. Additionally, if `as_a=:array` is specified, then the returned value is indeed an Array now.

Tests had to be somewhat reorganized and expanded to account for these changes.