### PR TITLE
fixes argument `constant` in `#compute`

### DIFF
--- a/lib/statsample-glm/glm/base.rb
+++ b/lib/statsample-glm/glm/base.rb
@@ -16,8 +16,11 @@ module Statsample
         @data_set  = ds.dup(ds.vectors.to_a - [y])
         @dependent = ds[y]
 
-        add_constant_vector if @opts[:constant]
-        add_constant_vector(1) if self.is_a? Statsample::GLM::Normal
+        if @opts[:constant]
+          add_constant_vector
+        else
+          add_constant_vector(1) if self.is_a? Statsample::GLM::Normal
+        end
 
         algorithm = @opts[:algorithm].upcase
         method    = @opts[:method].capitalize

--- a/spec/normal_spec.rb
+++ b/spec/normal_spec.rb
@@ -10,7 +10,14 @@ describe Statsample::GLM::Normal do
       @glm = Statsample::GLM.compute @ds, 'ROLL', :normal, {algorithm: :mle}
       
       expect_similar_vector @glm.coefficients, [450.12450365911894, 
-        0.4064837278023981, 4.27485769721736,-9153.254462671905]
+        0.4064837278023981, 4.27485769721736, -9153.254462671905]
+    end
+
+    it "reports correct values when constant is different from 1", focus: true do
+      @glm = Statsample::GLM.compute @ds, 'ROLL', :normal, {constant: 2, algorithm: :mle}
+      
+      expect_similar_vector @glm.coefficients, [450.12450365911894, 
+        0.4064837278023981, 4.27485769721736, -4576.627231335952]
     end
 
     it "computes predictions of new data correctly" do


### PR DESCRIPTION
So far it was not possible to specify a different `constant` argument than 1 in `Statsample::GLM#compute` for `Statsample::GLM::Normal`. This commit is a fix for it.