### PR TITLE
Fix build errors

### DIFF
--- a/lib/statsample-glm.rb
+++ b/lib/statsample-glm.rb
@@ -1,2 +1,3 @@
+require 'backports'
 require 'statsample'
 require 'statsample-glm/glm'

--- a/statsample-glm.gemspec
+++ b/statsample-glm.gemspec
@@ -29,6 +29,7 @@ Gem::Specification.new do |spec|
 
   spec.add_runtime_dependency 'daru', '~> 0.1'
   spec.add_runtime_dependency 'statsample', '~> 2.0'
+  spec.add_runtime_dependency 'backports'
 
   spec.add_development_dependency 'bundler', '~> 1.10'
   spec.add_development_dependency 'rake'


### PR DESCRIPTION
Fixes the build errors by:
- loading backports. It's a redundancy though since backports is also required by Daru. The reason for adding this again is mentioned below. 
- loading backports at the top so that it gets loaded before extendmatrix which is loaded through statsample. This is required because there were some failing specs.

Now the build is passing for all rubies except 1.9.3 but this we are going to drop.