### PR TITLE
Revert "Fix build errors"

### DIFF
--- a/lib/statsample-glm.rb
+++ b/lib/statsample-glm.rb
@@ -1,3 +1,2 @@
-require 'backports'
 require 'statsample'
 require 'statsample-glm/glm'

--- a/statsample-glm.gemspec
+++ b/statsample-glm.gemspec
@@ -29,7 +29,6 @@ Gem::Specification.new do |spec|
 
   spec.add_runtime_dependency 'daru', '~> 0.1'
   spec.add_runtime_dependency 'statsample', '~> 2.0'
-  spec.add_runtime_dependency 'backports'
 
   spec.add_development_dependency 'bundler', '~> 1.10'
   spec.add_development_dependency 'rake'


### PR DESCRIPTION
Reverts SciRuby/statsample-glm#25

backports is already present in daru, and the error that Travis is showing is because of an issue in daru, not statsample-glm. Backports should be loaded from daru.