### PR TITLE
Solve build error

### DIFF
--- a/lib/statsample-glm.rb
+++ b/lib/statsample-glm.rb
@@ -1,2 +1,3 @@
+require 'daru'
 require 'statsample'
 require 'statsample-glm/glm'


### PR DESCRIPTION
This PR is to load daru before statsample to make backports load before endmatrix. Loading endmatrix before backports leads to failing specs. See https://github.com/marcandre/backports/issues/101

Upon next daru release and merge of this PR, the statsample-glm build will pass.